### PR TITLE
add dynamic background color based on ratio

### DIFF
--- a/Ratios.xcodeproj/project.pbxproj
+++ b/Ratios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1BE39664205D68D7006F0D76 /* BrewStrengthColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE39663205D68D7006F0D76 /* BrewStrengthColor.swift */; };
 		BC0B331A1F72FCA80043719D /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0B33191F72FCA80043719D /* Theme.swift */; };
 		BC57D8641F51DF9A00A4ED41 /* LabelInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57D8631F51DF9A00A4ED41 /* LabelInputView.swift */; };
 		BC57D88B1F52042A00A4ED41 /* Tofino-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = BC57D87B1F5203F600A4ED41 /* Tofino-Black.otf */; };
@@ -45,6 +46,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1BE39663205D68D7006F0D76 /* BrewStrengthColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewStrengthColor.swift; sourceTree = "<group>"; };
 		BC0B33191F72FCA80043719D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		BC57D8631F51DF9A00A4ED41 /* LabelInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelInputView.swift; sourceTree = "<group>"; };
 		BC57D87A1F5203F600A4ED41 /* Tofino-BookItalic.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Tofino-BookItalic.otf"; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				BCEBCDB01F6D8C1D00805050 /* Assets.swift */,
 				BC57D89E1F5242BB00A4ED41 /* PersistenceStore.swift */,
 				BCEBCDB21F6DA89600805050 /* AppInfo.swift */,
+				1BE39663205D68D7006F0D76 /* BrewStrengthColor.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -326,6 +329,7 @@
 				BC57D89F1F5242BB00A4ED41 /* PersistenceStore.swift in Sources */,
 				BC57D8641F51DF9A00A4ED41 /* LabelInputView.swift in Sources */,
 				BC8A674F1F519E8400A7E627 /* Calculator.swift in Sources */,
+				1BE39664205D68D7006F0D76 /* BrewStrengthColor.swift in Sources */,
 				BC98F38D1F5C7BD800F6E1D4 /* KeyboardSection.swift in Sources */,
 				BC0B331A1F72FCA80043719D /* Theme.swift in Sources */,
 			);

--- a/Ratios/CalculatorViewController.swift
+++ b/Ratios/CalculatorViewController.swift
@@ -88,6 +88,8 @@ class CalculatorViewController: UIViewController {
             self.groundsInputView.textField.text = formatDoubleToString(values.grounds)
             self.waterInputView.textField.text = formatDoubleToString(water)
             self.totalInputView.textField.text = formatDoubleToString(brew)
+            
+            self.updateBackgroundColor(values.ratio)
         }
     }
 
@@ -113,6 +115,14 @@ class CalculatorViewController: UIViewController {
         }
 
         self.stackViewWidthConstraint?.isActive = true
+    }
+    
+    func updateBackgroundColor(_ ratio: Int, duration: TimeInterval = 0.15) {
+        UIView.animate(withDuration: duration) {
+            let newBackgroundColor = BrewStrengthColor.colorFor(ratio)
+            self.view.backgroundColor = newBackgroundColor
+            KeyboardViewController.shared.updateBackgroundColor(newBackgroundColor)
+        }
     }
 
     @objc func handleFieldValueChange(_ sender: AnyObject) {
@@ -148,6 +158,7 @@ class CalculatorViewController: UIViewController {
             break
         }
 
+        self.updateBackgroundColor(ratio)
         self.persistenceStore?.save(grounds: grounds, ratio: ratio)
     }
 

--- a/Ratios/Helpers/BrewStrengthColor.swift
+++ b/Ratios/Helpers/BrewStrengthColor.swift
@@ -1,0 +1,56 @@
+//
+//  RatioColour.swift
+//  Ratios
+//
+//  Created by Sasha Friedenberg on 03/17/2018.
+//  Copyright © 2018 Brushed Type. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+struct BrewStrengthColor {
+    static let strongBackgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
+    static let weakBackgroundColor   = UIColor(red: 1, green: 1, blue: 1, alpha: 1)
+    
+    static let minRatio: Int = 12
+    static let maxRatio: Int = 20
+    
+    static func colorFor(_ ratio: Int) -> UIColor {
+        guard ratio < maxRatio else {
+            //a ratio of 1/maxRatio produces a weaker brew
+            return weakBackgroundColor
+        }
+        
+        guard ratio > minRatio else {
+            //a ratio of 1/minRatio produces a stronger brew
+            return strongBackgroundColor
+        }
+        
+        let colorOffsetFraction = CGFloat(Double(ratio - minRatio) / Double(maxRatio - minRatio))
+        
+        var minRed: CGFloat = 0
+        var maxRed: CGFloat = 0
+        
+        var minGreen: CGFloat = 0
+        var maxGreen: CGFloat = 0
+        
+        var minBlue: CGFloat = 0
+        var maxBlue: CGFloat = 0
+        
+        strongBackgroundColor.getRed(&minRed, green: &minGreen, blue: &minBlue, alpha: nil)
+        weakBackgroundColor.getRed(&maxRed, green: &maxGreen, blue: &maxBlue, alpha: nil)
+        
+        let getNewColor = { (min: CGFloat, max: CGFloat) -> CGFloat in
+            return ((max - min) * colorOffsetFraction) + min
+        }
+        
+        let newRed      = getNewColor(minRed,   maxRed)
+        let newGreen    = getNewColor(minGreen, maxGreen)
+        let newBlue     = getNewColor(minBlue,  maxBlue)
+        
+        return UIColor(red: newRed, green: newGreen, blue: newBlue, alpha: 1)
+    }
+    
+    private init() {}
+}

--- a/Ratios/Helpers/BrewStrengthColour.swift
+++ b/Ratios/Helpers/BrewStrengthColour.swift
@@ -1,0 +1,56 @@
+//
+//  RatioColour.swift
+//  Ratios
+//
+//  Created by Sasha Friedenberg on 03/17/2018.
+//  Copyright © 2018 Brushed Type. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+struct BrewStrengthColour {
+    static let strongBackgroundColour = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
+    static let weakBackgroundColour   = UIColor(red: 1, green: 1, blue: 1, alpha: 1)
+    
+    static let minRatio: Int = 12
+    static let maxRatio: Int = 20
+    
+    static func colourFor(_ ratio: Int) -> UIColor {
+        guard ratio < maxRatio else {
+            //a ratio of 1/maxRatio produces a weaker brew
+            return weakBackgroundColour
+        }
+        
+        guard ratio > minRatio else {
+            //a ratio of 1/minRatio produces a stronger brew
+            return strongBackgroundColour
+        }
+        
+        let colourOffsetFraction = CGFloat(Double(ratio - minRatio) / Double(maxRatio - minRatio))
+        
+        var minRed: CGFloat = 0
+        var maxRed: CGFloat = 0
+        
+        var minGreen: CGFloat = 0
+        var maxGreen: CGFloat = 0
+        
+        var minBlue: CGFloat = 0
+        var maxBlue: CGFloat = 0
+        
+        strongBackgroundColour.getRed(&minRed, green: &minGreen, blue: &minBlue, alpha: nil)
+        weakBackgroundColour.getRed(&maxRed, green: &maxGreen, blue: &maxBlue, alpha: nil)
+        
+        let getNewColour = { (min: CGFloat, max: CGFloat) -> CGFloat in
+            return ((max - min) * colourOffsetFraction) + min
+        }
+        
+        let newRed      = getNewColour(minRed,   maxRed)
+        let newGreen    = getNewColour(minGreen, maxGreen)
+        let newBlue     = getNewColour(minBlue,  maxBlue)
+        
+        return UIColor(red: newRed, green: newGreen, blue: newBlue, alpha: 1)
+    }
+    
+    private init() {}
+}

--- a/Ratios/Keyboard/KeyboardViewController.swift
+++ b/Ratios/Keyboard/KeyboardViewController.swift
@@ -28,7 +28,7 @@ class KeyboardViewController: UIInputViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.view.backgroundColor = Theme.backgroundColour
+        self.updateBackgroundColor(Theme.backgroundColour)
         self.view.translatesAutoresizingMaskIntoConstraints = false
 
         let keyboardRows = self.rows.map({ [unowned self] buttonValues in
@@ -54,6 +54,10 @@ class KeyboardViewController: UIInputViewController {
         } else {
             keyboardView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -8).isActive = true
         }
+    }
+    
+    func updateBackgroundColor(_ color: UIColor) {
+        self.view.backgroundColor = color
     }
 
     @objc func handleKeyPress(_ sender: AnyObject?) {


### PR DESCRIPTION
| Low water:coffee ratio | High water:coffee ratio |
|-|-|
| ![simulator screen shot - iphone se - 2018-01-21 at 14 17 29](https://user-images.githubusercontent.com/181492/35197970-e6f848f8-feb5-11e7-8082-955e6b011e18.png) | ![simulator screen shot - iphone se - 2018-01-21 at 14 17 34](https://user-images.githubusercontent.com/181492/35197972-e7040454-feb5-11e7-9e4a-e4e5bde24b64.png) |

I added a feature to make the ratio a little bit more visceral, where the background color of the main screen animates to an alternate shade of the main theme's background color. The default of 16 is used for the main shade, and as the ratio moves further away from 16 in either direction, the shade offset decays with a [multiplicative inverse](https://en.wikipedia.org/wiki/Multiplicative_inverse) or something like that I don't know I'm not a mathematician.

Some things that could be improved:
- the default of `16` is currently hard-coded and should really be moved to a constant for the whole project
- there are some other things that should be moved to constants too

Things that couldn't be done:
- dynamically updating the launch screen background color to match whatever was persisted

Please let me know if you want any adjustments!